### PR TITLE
Add an option to clear the preferred totem via right-click

### DIFF
--- a/ShamanPower.lua
+++ b/ShamanPower.lua
@@ -5038,6 +5038,25 @@ function ShamanPower:CreateTotemButtons()
 			end
 		end)
 
+		-- PostClick hook: right-click clears the assigned totem for this slot (when option enabled)
+		btn:HookScript("PostClick", function(self, button)
+			if button == "RightButton" and ShamanPower.opt.rightClickClearsAssignment then
+				if InCombatLockdown() then
+					print("|cffff0000ShamanPower:|r " .. L["Cannot clear assignment during combat"])
+					return
+				end
+				local elem = self.element
+				if not ShamanPower_Assignments[ShamanPower.player] then
+					ShamanPower_Assignments[ShamanPower.player] = {}
+				end
+				ShamanPower_Assignments[ShamanPower.player][elem] = 0
+				ShamanPower:UpdateMiniTotemBar()
+				ShamanPower:UpdateDropAllButton()
+				ShamanPower:UpdateSPMacros()
+				ShamanPower:SendMessage("ASSIGN " .. ShamanPower.player .. " " .. elem .. " 0")
+			end
+		end)
+
 		btn:Show()
 		self.totemButtons[element] = btn
 	end
@@ -5194,6 +5213,10 @@ function ShamanPower:UpdateTotemButtons()
 					btn:SetAttribute("type2", "spell")
 					btn:SetAttribute("spell2", GetSpellInfo(36936))  -- Totemic Call
 				end
+			elseif self.opt.rightClickClearsAssignment then
+				-- Right-click clears the assigned totem for this slot (handled by PostClick hook)
+				btn:SetAttribute("type2", nil)
+				btn:SetAttribute("spell2", nil)
 			else
 				-- Right-click to cast Totemic Call (destroys all totems)
 				btn:SetAttribute("type2", "spell")
@@ -6026,6 +6049,10 @@ function ShamanPower:UpdateTotemFlyoutEnabled()
 						btn:SetAttribute("type2", "spell")
 						btn:SetAttribute("spell2", totemicCallName)
 					end
+				elseif self.opt.rightClickClearsAssignment then
+					-- Right-click clears the assigned totem for this slot (handled by PostClick hook)
+					btn:SetAttribute("type2", nil)
+					btn:SetAttribute("spell2", nil)
 				else
 					btn:SetAttribute("type2", "spell")
 					btn:SetAttribute("spell2", totemicCallName)
@@ -6057,6 +6084,10 @@ function ShamanPower:UpdateTotemFlyoutEnabled()
 						btn:SetAttribute("type2", "spell")
 						btn:SetAttribute("spell2", totemicCallName)
 					end
+				elseif self.opt.rightClickClearsAssignment then
+					-- Right-click clears the assigned totem for this slot (handled by PostClick hook)
+					btn:SetAttribute("type2", nil)
+					btn:SetAttribute("spell2", nil)
 				else
 					btn:SetAttribute("type2", "spell")
 					btn:SetAttribute("spell2", totemicCallName)
@@ -9316,6 +9347,10 @@ function ShamanPower:UpdateMiniTotemBar()
 						totemButton:SetAttribute("type2", "spell")
 						totemButton:SetAttribute("spell2", GetSpellInfo(36936))  -- Totemic Call
 					end
+				elseif self.opt.rightClickClearsAssignment then
+					-- Right-click clears the assigned totem for this slot (handled by PostClick hook)
+					totemButton:SetAttribute("type2", nil)
+					totemButton:SetAttribute("spell2", nil)
 				else
 					-- Right-click to cast Totemic Call (destroys all totems)
 					totemButton:SetAttribute("type2", "spell")
@@ -9564,6 +9599,8 @@ function ShamanPower:TotemBarTooltip(button, element)
 			GameTooltip:AddLine("|cffffcc00Right-click:|r Show flyout", 0.7, 0.7, 0.7)
 		elseif self.opt.activeTotemAsMain and self.opt.rightClickCastsAssigned then
 			GameTooltip:AddLine("|cffffcc00Right-click:|r Drop corner totem (" .. totemName .. ")", 0.7, 0.7, 0.7)
+		elseif self.opt.rightClickClearsAssignment then
+			GameTooltip:AddLine("|cffffcc00Right-click:|r Clear assignment", 0.7, 0.7, 0.7)
 		else
 			GameTooltip:AddLine("|cffffcc00Right-click:|r Totemic Call", 0.7, 0.7, 0.7)
 		end

--- a/ShamanPowerOptions.lua
+++ b/ShamanPowerOptions.lua
@@ -810,6 +810,26 @@ ShamanPower.options = {
 								ShamanPower:UpdateMiniTotemBar()
 							end
 						},
+						rightClickClearsAssignment = {
+							order = 4.7,
+							name = L["Right-Click Clears Assignment"],
+							desc = L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"],
+							type = "toggle",
+							width = "full",
+							hidden = function(info)
+								return ShamanPower.opt.flyoutRequiresClick or (ShamanPower.opt.activeTotemAsMain and ShamanPower.opt.rightClickCastsAssigned)
+							end,
+							disabled = function(info)
+								return ShamanPower.opt.enabled == false
+							end,
+							get = function(info)
+								return ShamanPower.opt.rightClickClearsAssignment
+							end,
+							set = function(info, val)
+								ShamanPower.opt.rightClickClearsAssignment = val
+								ShamanPower:UpdateMiniTotemBar()
+							end
+						},
 						twistSpacer = {
 							order = 5,
 							type = "description",

--- a/ShamanPowerValues.lua
+++ b/ShamanPowerValues.lua
@@ -168,6 +168,7 @@ SHAMANPOWER_DEFAULT_VALUES = {
         dynamicTotemMode = false,  -- Dynamic Mode: bar shows active totems instead of assigned (for PVP)
         activeTotemAsMain = false,  -- TotemTimers style: show active totem as main icon, assigned as small corner indicator
         rightClickCastsAssigned = false,  -- In TotemTimers mode: right-click casts assigned totem instead of Totemic Call
+        rightClickClearsAssignment = false,  -- Right-click a totem button to clear (unassign) that slot instead of casting Totemic Call
         enableMiddleClickPopOut = true,  -- Allow middle-click to pop out buttons as standalone trackers
         -- Totem Loadout bar settings
         showLoadoutBar = false,         -- Show/hide the loadout flyout anchor (off until first loadout saved)

--- a/locale/deDE.lua
+++ b/locale/deDE.lua
@@ -195,3 +195,10 @@ L["Wait for Players"] = "Warte auf Mitspieler ..."
 L["What to buff with ShamanPower"] = "Welche Ziele mit ShamanPower gebuffed werden sollen"
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "Während du in einem Raid-Dungeon unterwegs bist, werden Spieler ausgeblendet, die nich tin den für das Dungeon üblichen Gruppen sind. Zum Beispiel, wenn du in einem 10-Spieler Dungeon bist, werden alle Spieler in Gruppe 3 oder höher ausgeblendet."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -232,3 +232,8 @@ L["Use in Party"] = "Use in Party"
 L["Use when Solo"] = "Use when Solo"
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon."
 L["...with Normal..."] = "...with Normal..."
+
+-- Right-click clears assignment option
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/esES.lua
+++ b/locale/esES.lua
@@ -196,3 +196,10 @@ L["What to buff with ShamanPower"] = "Qué mejorar con ShamanPower"
 --[[Translation missing --]]
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/esMX.lua
+++ b/locale/esMX.lua
@@ -193,3 +193,10 @@ L["What to buff with ShamanPower"] = "Qué mejorar con ShamanPower"
 --[[Translation missing --]]
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/frFR.lua
+++ b/locale/frFR.lua
@@ -186,3 +186,10 @@ L["What to buff with ShamanPower"] = "Que buff avec ShamanPower"
 --[[Translation missing --]]
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/koKR.lua
+++ b/locale/koKR.lua
@@ -199,3 +199,10 @@ L["What to buff with ShamanPower"] = "ShamanPower로 버프할 내용"
 --[[Translation missing --]]
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/ptBR.lua
+++ b/locale/ptBR.lua
@@ -200,3 +200,10 @@ L["What to buff with ShamanPower"] = "O que buffar com o ShamanPower"
 --[[Translation missing --]]
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -177,3 +177,10 @@ L["Wait for Players"] = "Ожидать игроков"
 L["What to buff with ShamanPower"] = "Что баффать при помощи ShamanPower"
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "Пока вы находитесь в рейдовом подземелье, скроет всех игроков, не входящих в обычные подгруппы для этого подземелья. Например, если вы находитесь в подземелье на 10 игроков, все игроки из группы 3 и выше будут скрыты."
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/zhCN.lua
+++ b/locale/zhCN.lua
@@ -165,3 +165,10 @@ L["Wait for Players"] = "启用等待玩家"
 L["What to buff with ShamanPower"] = "使用ShamanPower进行的buff"
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "当你在一个团队副本中时，自动隐藏其他不在正常副本团队中的玩家。例如：当你在一个10人副本中时，其他在3队或者3队之后的玩家，会被隐藏"
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"

--- a/locale/zhTW.lua
+++ b/locale/zhTW.lua
@@ -167,3 +167,10 @@ L["Wait for Players"] = "啟用等待玩家"
 L["What to buff with ShamanPower"] = "要用聖騎威能施放何種增益"
 L["While you are in a Raid dungeon, hide any players outside of the usual subgroups for that dungeon. For example, if you are in a 10-player dungeon, any players in Group 3 or higher will be hidden."] = "當您在團隊副本時，將所有在常規隊伍外的玩家隱藏。 例如，如果您在10人副本中，則第3隊或其他排在更後面的隊伍玩家都將被隱藏。"
 
+-- Right-click clears assignment option
+--[[Translation missing --]]
+L["Right-Click Clears Assignment"] = "Right-Click Clears Assignment"
+--[[Translation missing --]]
+L["RIGHTCLICK_CLEARS_ASSIGNMENT_DESC"] = "When enabled, right-clicking a totem button will clear (unassign) the totem for that slot instead of casting Totemic Call. Only works outside of combat."
+--[[Translation missing --]]
+L["Cannot clear assignment during combat"] = "Cannot clear assignment during combat"


### PR DESCRIPTION
Adds an option to right click clear the preferred totem via a right-click instead of having to open the menu and scroll thru to the blank option. Closes https://github.com/taubut/ShamanPower/issues/5