### PR TITLE
Fix flyouts closing instantly on mouse-leave (patch 2.5.6)

### DIFF
--- a/ShamanPower.lua
+++ b/ShamanPower.lua
@@ -29,6 +29,32 @@ for name, path in pairs(SP_SOUNDS) do
 end
 local LUIDDM = LibStub("LibUIDropDownMenu-4.0")
 
+-- Patch 2.5.6+: IsUnderMouse(true) returns nil in the secure restricted
+-- environment (recursive form broken by the Midnight shared UI code brought
+-- to Classic). "not nil" is true, so flyouts closed unconditionally on every
+-- OnLeave. Fix: walk children explicitly using the still-working
+-- non-recursive IsUnderMouse().
+local SP_SECURE_ONLEAVE_SELF = [[
+	if self:IsUnderMouse() then return end
+	local children = newtable(self:GetChildren())
+	for i = 1, #children do
+		local c = children[i]
+		if c:IsShown() and c:IsUnderMouse() then return end
+	end
+	self:ChildUpdate("show", false)
+]]
+
+local SP_SECURE_ONLEAVE_PARENT = [[
+	local parent = self:GetParent()
+	if parent:IsUnderMouse() then return end
+	local children = newtable(parent:GetChildren())
+	for i = 1, #children do
+		local c = children[i]
+		if c:IsShown() and c:IsUnderMouse() then return end
+	end
+	parent:ChildUpdate("show", false)
+]]
+
 local LCD = (ShamanPower.isVanilla) and LibStub("LibClassicDurations", true)
 local UnitAura = LCD and LCD.UnitAuraWrapper or UnitAura
 
@@ -4959,11 +4985,7 @@ function ShamanPower:CreateTotemButtons()
 		]])
 
 		-- SECURE HANDLER: Hide flyout on leave (WORKS IN COMBAT)
-		btn:SetAttribute("_onleave", [[
-			if not self:IsUnderMouse(true) then
-				self:ChildUpdate("show", false)
-			end
-		]])
+		btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_SELF)
 
 		-- SECURE HANDLER: Show flyout on right-click when in click mode (WORKS IN COMBAT)
 		btn:SetAttribute("_onmouseup", [[
@@ -5359,11 +5381,7 @@ function ShamanPower:CreateTotemFlyout(element)
 			]])
 
 			-- SECURE HANDLER: Check parent on leave (WORKS IN COMBAT)
-			btn:SetAttribute("_onleave", [[
-				if not self:GetParent():IsUnderMouse(true) then
-					self:GetParent():ChildUpdate("show", false)
-				end
-			]])
+			btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_PARENT)
 
 			-- Store spell info as attributes for secure snippets
 			btn:SetAttribute("mySpell", spellName)
@@ -6648,11 +6666,7 @@ function ShamanPower:CreateCooldownBar()
 				]])
 
 				-- SECURE HANDLER: Hide flyout on leave (WORKS IN COMBAT)
-				btn:SetAttribute("_onleave", [[
-					if not self:IsUnderMouse(true) then
-						self:ChildUpdate("show", false)
-					end
-				]])
+				btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_SELF)
 
 				-- SECURE HANDLER: Show flyout on right-click when in click mode (WORKS IN COMBAT)
 				btn:SetAttribute("_onmouseup", [[
@@ -8512,11 +8526,7 @@ function ShamanPower:CreateWeaponImbueButton()
 	]])
 
 	-- SECURE HANDLER: Hide flyout on leave (WORKS IN COMBAT)
-	btn:SetAttribute("_onleave", [[
-		if not self:IsUnderMouse(true) then
-			self:ChildUpdate("show", false)
-		end
-	]])
+	btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_SELF)
 
 	-- SECURE HANDLER: Show flyout on right-click when in click mode (WORKS IN COMBAT)
 	btn:SetAttribute("_onmouseup", [[
@@ -8650,11 +8660,7 @@ function ShamanPower:CreateShieldFlyout()
 			]])
 
 			-- SECURE HANDLER: Check parent on leave (WORKS IN COMBAT)
-			btn:SetAttribute("_onleave", [[
-				if not self:GetParent():IsUnderMouse(true) then
-					self:GetParent():ChildUpdate("show", false)
-				end
-			]])
+			btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_PARENT)
 
 			-- Left-click casts shield; right-click has no type2 so no cast happens
 			btn:SetAttribute("type1", "spell")
@@ -8844,11 +8850,7 @@ function ShamanPower:CreateWeaponImbueFlyout()
 			]])
 
 			-- SECURE HANDLER: Check parent on leave (WORKS IN COMBAT)
-			btn:SetAttribute("_onleave", [[
-				if not self:GetParent():IsUnderMouse(true) then
-					self:GetParent():ChildUpdate("show", false)
-				end
-			]])
+			btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_PARENT)
 
 			-- Click to cast imbue spell (left=main hand, right=off hand)
 			local mainHandMacro = "/cast [@none] " .. spellName .. "\n/use 16\n/click StaticPopup1Button1"
@@ -9639,11 +9641,7 @@ function ShamanPower:CreateEarthShieldButton()
 			self:ChildUpdate("show", true)
 		end
 	]])
-	esBtn:SetAttribute("_onleave", [[
-		if not self:IsUnderMouse(true) then
-			self:ChildUpdate("show", false)
-		end
-	]])
+	esBtn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_SELF)
 
 	-- Icon (use the template's icon - $parentIcon becomes ShamanPowerEarthShieldBtnIcon)
 	local icon = _G[esBtn:GetName() .. "Icon"]
@@ -10099,11 +10097,7 @@ function ShamanPower:UpdateOrCreateESFlyoutButton(index, name, class, unit, esBt
 		]])
 
 		-- SECURE HANDLER: Check parent on leave
-		btn:SetAttribute("_onleave", [[
-			if not self:GetParent():IsUnderMouse(true) then
-				self:GetParent():ChildUpdate("show", false)
-			end
-		]])
+		btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_PARENT)
 
 		btn:RegisterForClicks("AnyUp", "AnyDown")
 
@@ -16603,11 +16597,7 @@ function ShamanPower:CreateLoadoutBar()
 		self:ChildUpdate("show", true)
 	]])
 
-	anchor:SetAttribute("_onleave", [[
-		if not self:IsUnderMouse(true) then
-			self:ChildUpdate("show", false)
-		end
-	]])
+	anchor:SetAttribute("_onleave", SP_SECURE_ONLEAVE_SELF)
 
 	-- Anchor normal texture (standard WoW action button look)
 	local normalTex = anchor:CreateTexture(nil, "BORDER")
@@ -16703,11 +16693,7 @@ function ShamanPower:CreateLoadoutBar()
 
 		-- SECURE HANDLER: Hide flyout when mouse leaves set button (if not over parent anchor)
 		-- Same pattern as totem flyout _onleave
-		btn:SetAttribute("_onleave", [[
-			if not self:GetParent():IsUnderMouse(true) then
-				self:GetParent():ChildUpdate("show", false)
-			end
-		]])
+		btn:SetAttribute("_onleave", SP_SECURE_ONLEAVE_PARENT)
 
 		-- SECURE HANDLER: Toggle visibility on parent ChildUpdate("toggle")
 		-- Same as TotemTimers: _childupdate-toggle


### PR DESCRIPTION
## Problem

Since patch 2.5.6, all mouseover flyouts (totems, shield, weapon imbue, Earth Shield, cooldown bar, loadout bar) close instantly when the cursor leaves the parent button, making them unusable.

## Cause

The `_onleave` secure snippets check `self:IsUnderMouse(true)`, which now returns `nil` in the secure restricted environment on the 2.5.6 client (likely related to the shared modern UI code introduced this patch). `not nil` is true, so the flyout hides unconditionally on every leave.

## Fix

Replace the recursive check with an explicit walk of child frames using the still-working non-recursive `IsUnderMouse()`. Two shared snippet constants, applied to all 10 affected `_onleave` sites. No behavior change otherwise; stays fully inside the secure environment so combat works.

## Tested

Totem flyouts on TBC Anniversary 2.5.6 — traversal, casting, and correct close on genuine leave. [other flyouts / combat: adjust to what you've verified]

Note: Era/SoD/HC get the same client code in 1.15.9 (week of July 19), so the Vanilla flavor will likely be affected too; the fixed snippets are shared.